### PR TITLE
Guarantee the rocket to leave the screen

### DIFF
--- a/css/rocket.css
+++ b/css/rocket.css
@@ -83,7 +83,7 @@ body.body-state1 .rocket{
 
 body.body-state3 .rocket,
 body.body-state4 .rocket{
-    bottom: 1000px;
+    bottom: 100vh; /* guaranteed to send the rocket outside of the screen */
 }
 
 .state1,


### PR DESCRIPTION
On mobile devices the rocket does not leave the screen because the height of the display is bigger than 1000px. I guess this is unexpected.

100vh means "100 percent of screen height". Setting the rocket's destination to such a point will guarantee cross-device compatibility! :smiley: 